### PR TITLE
fix(react): correct accessibility defects across components

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,23 @@ pnpm clean          # Remove dist/ from all packages
 5. Add tests in `packages/react/tests/components.test.tsx`
 6. Update the component count in READMEs if it changes
 
+### Accessibility requirements
+
+Every component must meet these before merge:
+
+- Generate ids with `useId()`, never from a prop. The same `name` can appear
+  twice in one stream, and duplicate ids break `<label for>`.
+- Pair every control with a `<label htmlFor>`, or give it an `aria-label`.
+- Reflect `isStreaming` as `disabled`/`aria-disabled` on interactive controls.
+  Silently dropping the event leaves the control looking live.
+- Prefer native elements (`<details>`, `<table>`, `<button>`). If you use an
+  ARIA role, implement its full keyboard pattern — arrows, Home, End, and
+  roving `tabIndex`. `Tabs` in `layout.tsx` is the reference.
+- Anything conveying data must expose that data to assistive tech, not just a
+  type name. `describeChart` in `data.tsx` is the reference.
+- Never leave focusable content inside `aria-hidden`. Use `inert` as well;
+  `pointer-events: none` stops the mouse but not the keyboard.
+
 ## Pull Request Guidelines
 
 - Keep PRs focused — one feature or fix per PR

--- a/packages/react/src/components/data.tsx
+++ b/packages/react/src/components/data.tsx
@@ -1,5 +1,38 @@
 import type { ComponentProps } from '../context'
 
+// A chart is data, but role="img" exposes only its label — so the label has to
+// carry the data. Long series are summarised rather than read out in full.
+const MAX_SPOKEN_POINTS = 12
+
+function describeChart(
+	type: string,
+	labels: unknown[],
+	values: number[],
+	title: string | undefined,
+): string {
+	const prefix = title ? `${title} — ` : ''
+	if (values.length === 0) return `${prefix}${type} chart`
+
+	// Values reach here unvalidated when the registry runs in coerce mode, so a
+	// non-numeric prop can land as NaN. Skip those rather than speak them.
+	const finite = values.filter((v) => Number.isFinite(v))
+	const count = `${values.length} data point${values.length === 1 ? '' : 's'}`
+	if (finite.length === 0) return `${prefix}${type} chart, ${count}`
+
+	if (values.length > MAX_SPOKEN_POINTS) {
+		const min = finite.reduce((a, b) => Math.min(a, b), finite[0])
+		const max = finite.reduce((a, b) => Math.max(a, b), finite[0])
+		return `${prefix}${type} chart, ${count}, values from ${min} to ${max}`
+	}
+
+	const pairs = values.flatMap((v, i) => {
+		if (!Number.isFinite(v)) return []
+		const label = labels[i]
+		return [label === undefined ? String(v) : `${String(label)} ${v}`]
+	})
+	return `${prefix}${type} chart, ${count}: ${pairs.join(', ')}`
+}
+
 export function Chart({ props, className }: ComponentProps) {
 	const type = props.type as string
 	const labels = Array.isArray(props.labels) ? props.labels : []
@@ -14,7 +47,7 @@ export function Chart({ props, className }: ComponentProps) {
 			data-mdocui-chart
 			data-type={type}
 			role="img"
-			aria-label={title ?? `${type} chart`}
+			aria-label={describeChart(type, labels, values, title)}
 			style={themed ? undefined : { padding: '12px 0' }}
 		>
 			{title && (
@@ -121,6 +154,7 @@ export function Table({ props, className }: ComponentProps) {
 					{headers.map((h) => (
 						<th
 							key={h}
+							scope="col"
 							style={
 								themed
 									? undefined

--- a/packages/react/src/components/interactive.tsx
+++ b/packages/react/src/components/interactive.tsx
@@ -1,5 +1,5 @@
 import type { ActionEvent } from '@mdocui/core'
-import { useState } from 'react'
+import { useId, useState } from 'react'
 import type { ComponentProps } from '../context'
 
 export function Button({ props, className, onAction, isStreaming }: ComponentProps) {
@@ -95,7 +95,8 @@ export function Input({ props, className }: ComponentProps) {
 	const min = props.min as number | undefined
 	const max = props.max as number | undefined
 	const step = props.step as number | undefined
-	const id = `mdocui-${name}`
+	const uid = useId()
+	const id = `mdocui-${name}-${uid}`
 	const themed = !!className
 
 	return (
@@ -150,7 +151,8 @@ export function Textarea({ props, className }: ComponentProps) {
 	const required = (props.required as boolean) ?? false
 	const minLength = props.minLength as number | undefined
 	const maxLength = props.maxLength as number | undefined
-	const id = `mdocui-${name}`
+	const uid = useId()
+	const id = `mdocui-${name}-${uid}`
 	const themed = !!className
 
 	return (
@@ -228,6 +230,8 @@ export function Toggle({ props, className, onAction, isStreaming }: ComponentPro
 				aria-checked={isChecked}
 				name={name}
 				checked={isChecked}
+				disabled={isStreaming}
+				aria-disabled={isStreaming || undefined}
 				onChange={handleChange}
 			/>
 			<span>{label}</span>
@@ -241,7 +245,8 @@ export function Select({ props, className, onAction, isStreaming }: ComponentPro
 	const options = Array.isArray(props.options) ? props.options : []
 	const placeholder = props.placeholder as string | undefined
 	const required = (props.required as boolean) ?? false
-	const id = `mdocui-${name}`
+	const uid = useId()
+	const id = `mdocui-${name}-${uid}`
 	const themed = !!className
 
 	const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -271,6 +276,8 @@ export function Select({ props, className, onAction, isStreaming }: ComponentPro
 				required={required}
 				aria-required={required || undefined}
 				aria-label={label ? undefined : name}
+				disabled={isStreaming}
+				aria-disabled={isStreaming || undefined}
 				onChange={handleChange}
 				style={
 					themed
@@ -324,7 +331,14 @@ export function Checkbox({ props, className, onAction, isStreaming }: ComponentP
 					: { display: 'flex', alignItems: 'center', gap: '8px', cursor: 'pointer' }
 			}
 		>
-			<input type="checkbox" name={name} checked={isChecked} onChange={handleChange} />
+			<input
+				type="checkbox"
+				name={name}
+				checked={isChecked}
+				disabled={isStreaming}
+				aria-disabled={isStreaming || undefined}
+				onChange={handleChange}
+			/>
 			<span>{label}</span>
 		</label>
 	)
@@ -359,6 +373,9 @@ export function Form({ props, className, children, onAction, isStreaming }: Comp
 	}
 
 	if (submitted) {
+		// inert, not just pointer-events: without it the submitted fields stay
+		// tab-focusable while aria-hidden keeps them from assistive tech.
+		// Passed as a string so it works across the React >=18 peer range.
 		return (
 			<div
 				className={className}
@@ -366,6 +383,7 @@ export function Form({ props, className, children, onAction, isStreaming }: Comp
 				data-name={formName}
 				data-submitted
 				aria-hidden="true"
+				{...{ inert: 'true' }}
 				style={
 					themed
 						? { opacity: 0.5, pointerEvents: 'none' }

--- a/packages/react/src/components/layout.tsx
+++ b/packages/react/src/components/layout.tsx
@@ -138,6 +138,8 @@ export function Tabs({ props, className, children }: ComponentProps) {
 			let next: number
 			if (e.key === 'ArrowRight') next = (active + 1) % labels.length
 			else if (e.key === 'ArrowLeft') next = (active - 1 + labels.length) % labels.length
+			else if (e.key === 'Home') next = 0
+			else if (e.key === 'End') next = labels.length - 1
 			else return
 			e.preventDefault()
 			setActive(next)
@@ -154,6 +156,7 @@ export function Tabs({ props, className, children }: ComponentProps) {
 				role="tablist"
 				data-mdocui-tablist
 				aria-label={labels.join(', ')}
+				aria-orientation="horizontal"
 				onKeyDown={handleKeyDown}
 				style={
 					themed

--- a/packages/react/tests/components.test.tsx
+++ b/packages/react/tests/components.test.tsx
@@ -450,3 +450,126 @@ describe('Content components', () => {
 		expect(handler).not.toHaveBeenCalled()
 	})
 })
+
+describe('Accessibility', () => {
+	it('gives each input a unique id even when names collide', () => {
+		const { container } = renderNodes([
+			componentNode('input', { name: 'email', label: 'Work email' }),
+			componentNode('input', { name: 'email', label: 'Personal email' }),
+		])
+		const ids = Array.from(container.querySelectorAll('input')).map((el) => el.id)
+		expect(ids).toHaveLength(2)
+		expect(ids[0]).not.toBe(ids[1])
+	})
+
+	it('associates every label with its own control', () => {
+		const { container } = renderNodes([
+			componentNode('input', { name: 'email', label: 'Work email' }),
+			componentNode('input', { name: 'email', label: 'Personal email' }),
+		])
+		for (const label of Array.from(container.querySelectorAll('label'))) {
+			const target = container.querySelector(`#${CSS.escape(label.htmlFor)}`)
+			expect(target).not.toBeNull()
+		}
+	})
+
+	it('disables toggle, checkbox and select while streaming', () => {
+		const { container } = renderNodes(
+			[
+				componentNode('toggle', { name: 'notify', label: 'Notify me' }),
+				componentNode('checkbox', { name: 'agree', label: 'I agree' }),
+				componentNode('select', { name: 'plan', options: ['a', 'b'] }),
+			],
+			vi.fn(),
+			true,
+		)
+		for (const el of Array.from(container.querySelectorAll('input, select'))) {
+			expect((el as HTMLInputElement).disabled).toBe(true)
+		}
+	})
+
+	it('describes chart data in the accessible label', () => {
+		const { container } = renderNodes([
+			componentNode('chart', {
+				type: 'bar',
+				labels: ['Jan', 'Feb'],
+				values: [120, 150],
+				title: 'Revenue',
+			}),
+		])
+		const label = container.querySelector('[role="img"]')?.getAttribute('aria-label') ?? ''
+		expect(label).toContain('Revenue')
+		expect(label).toContain('Jan 120')
+		expect(label).toContain('Feb 150')
+	})
+
+	it('summarises long series instead of reading every point', () => {
+		const values = Array.from({ length: 40 }, (_, i) => i + 1)
+		const { container } = renderNodes([componentNode('chart', { type: 'line', values })])
+		const label = container.querySelector('[role="img"]')?.getAttribute('aria-label') ?? ''
+		expect(label).toContain('40 data points')
+		expect(label).toContain('1 to 40')
+	})
+
+	it('says data point, singular, for a one-point chart', () => {
+		const { container } = renderNodes([
+			componentNode('chart', { type: 'bar', labels: ['Jan'], values: [1] }),
+		])
+		const label = container.querySelector('[role="img"]')?.getAttribute('aria-label') ?? ''
+		expect(label).toContain('1 data point:')
+		expect(label).not.toContain('1 data points')
+	})
+
+	it('does not speak non-numeric chart values', () => {
+		const short = renderNodes([
+			componentNode('chart', { type: 'bar', labels: ['Jan', 'Feb'], values: ['x', 150] }),
+		])
+		const shortLabel =
+			short.container.querySelector('[role="img"]')?.getAttribute('aria-label') ?? ''
+		expect(shortLabel).not.toContain('NaN')
+		expect(shortLabel).toContain('Feb 150')
+
+		const values = Array.from({ length: 20 }, (_, i) => (i === 3 ? 'x' : i))
+		const long = renderNodes([componentNode('chart', { type: 'line', values })])
+		const longLabel = long.container.querySelector('[role="img"]')?.getAttribute('aria-label') ?? ''
+		expect(longLabel).not.toContain('NaN')
+		expect(longLabel).toContain('20 data points')
+	})
+
+	it('marks table headers as column headers', () => {
+		const { container } = renderNodes([
+			componentNode('table', { headers: ['Name', 'Value'], rows: [['a', '1']] }),
+		])
+		const headers = Array.from(container.querySelectorAll('th'))
+		expect(headers).toHaveLength(2)
+		for (const th of headers) expect(th.getAttribute('scope')).toBe('col')
+	})
+
+	it('moves to first and last tab with Home and End', () => {
+		const { container } = renderNodes([
+			componentNode('tabs', { labels: ['One', 'Two', 'Three'] }, [
+				componentNode('tab', { label: 'One' }, [{ type: 'prose', content: 'first' }]),
+				componentNode('tab', { label: 'Two' }, [{ type: 'prose', content: 'second' }]),
+				componentNode('tab', { label: 'Three' }, [{ type: 'prose', content: 'third' }]),
+			]),
+		])
+		const tablist = container.querySelector('[role="tablist"]') as HTMLElement
+		fireEvent.keyDown(tablist, { key: 'End' })
+		expect(screen.getByText('third')).toBeDefined()
+		fireEvent.keyDown(tablist, { key: 'Home' })
+		expect(screen.getByText('first')).toBeDefined()
+	})
+
+	it('keeps a submitted form out of the tab order', () => {
+		const { container } = renderNodes([
+			componentNode('form', { name: 'signup' }, [
+				componentNode('input', { name: 'email', label: 'Email' }),
+				componentNode('button', { action: 'submit', label: 'Send' }),
+			]),
+		])
+		const form = container.querySelector('form') as HTMLFormElement
+		fireEvent.submit(form)
+		const submitted = container.querySelector('[data-submitted]')
+		expect(submitted?.hasAttribute('inert')).toBe(true)
+	})
+})


### PR DESCRIPTION
Audit of the 23 built-in components. Behaviour fixes only — no API changes, no new dependencies.

| Component | Fix |
|---|---|
| Input, Textarea, Select | ids from `useId()`; `mdocui-${name}` collided when two fields share a name |
| Toggle, Checkbox, Select | `disabled` while streaming; previously a silent no-op |
| Form | `inert` when submitted; `aria-hidden` with `pointer-events: none` left fields tab-focusable |
| Chart | `aria-label` describes the data, not just the type |
| Table | `scope="col"` on headers |
| Tabs | Home/End keys, `aria-orientation` |

`inert` is passed as a string: a boolean warns on React 18 and the peer range is `>=18`.

Toggles, checkboxes and selects now grey out while streaming, matching buttons.

CONTRIBUTING.md gains an accessibility checklist. 224 tests pass, 8 new.