### PR TITLE
chore: bump to v0.7.3, document accessibility guarantees

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Generative UI library for LLMs using Markdoc `{% %}` tag syntax inline with mark
 
 LLMs write natural markdown **and** drop interactive UI components in the same stream — charts, buttons, forms, tables, cards, and more. No custom DSL to learn, no JSON blocks, no JSX confusion.
 
-**Key features:** built-in prose rendering, component merging, CLI scaffolder, error boundaries, streaming animations, shimmer placeholders, prop validation, context data passthrough, and configurable prompt verbosity.
+**Key features:** built-in prose rendering, component merging, CLI scaffolder, error boundaries, streaming animations, shimmer placeholders, prop validation, context data passthrough, configurable prompt verbosity, and accessible components.
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/mdocui/.github/main/assets/demo.gif" alt="mdocUI demo — streaming dashboard with charts, stats, and tables" width="800">

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mdocui/cli",
-	"version": "0.7.0",
+	"version": "0.7.3",
 	"description": "CLI for mdocUI — scaffold, generate system prompts, preview",
 	"type": "module",
 	"bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mdocui/core",
-	"version": "0.7.2",
+	"version": "0.7.3",
 	"description": "Streaming Markdoc parser, component registry, and system prompt generator for LLM generative UI",
 	"type": "module",
 	"main": "./dist/index.cjs",

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -298,6 +298,25 @@ This keeps the UI stable during streaming and component updates.
 
 ---
 
+## Accessibility
+
+The built-in components are keyboard and screen-reader ready out of the box:
+
+- Labels are tied to their control, with ids generated per instance so repeated
+  field names in one stream cannot cross-wire them
+- Controls that emit actions — `button`, `toggle`, `checkbox`, `select` — are
+  disabled while streaming rather than silently ignoring input. `input` and
+  `textarea` stay editable, so a form can be filled while the rest arrives
+- `tabs` implements the full ARIA tab pattern — arrows, Home, End, and a roving
+  tab stop; `accordion` uses native `<details>`
+- `chart` announces its data, not just its type: "Revenue — bar chart, 3 data
+  points: Jan 120, Feb 150, Mar 180". Series longer than 12 points are
+  summarised by count and range
+- A submitted `form` is removed from the tab order, not just dimmed
+
+If you replace a built-in with your own component, these guarantees are yours to
+maintain. See CONTRIBUTING.md for the checklist.
+
 ## Custom Components
 
 Pass custom components via the `components` prop — they merge on top of the 24 built-in defaults. You only need to pass overrides, not the full map:

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mdocui/react",
-	"version": "0.7.2",
+	"version": "0.7.3",
 	"description": "React adapter for mdocUI — Renderer, useRenderer hook, default generative UI components",
 	"type": "module",
 	"main": "./dist/index.cjs",


### PR DESCRIPTION
Release bump for the accessibility fixes in #22, plus the documentation those fixes needed.

## Version

| Package | From | To |
|---|---|---|
| @mdocui/core | 0.7.2 | 0.7.3 |
| @mdocui/react | 0.7.2 | 0.7.3 |
| @mdocui/cli | 0.7.0 | 0.7.3 |

Only `@mdocui/react` has shipped code changes; the other merges since 0.7.2 were CI and tooling. `core` and `cli` are bumped to bring all three back into sync — `cli` had drifted two patches behind — so one version identifies one state of the repo.

## Accessibility docs

#22 made the built-in components keyboard and screen-reader ready, but nothing said so. Adds an Accessibility section to the react README covering label association, disabled-while-streaming, the ARIA tab pattern, chart data announcement, and submitted-form focus removal — and adds it to the key features line in the root README.

Two accuracy checks while writing it:

- The chart example in the docs is the literal output of `describeChart`, verified against the code rather than written from memory.
- An earlier draft claimed all interactive controls are disabled while streaming. `input` and `textarea` are not, and should not be — they emit no actions and the form blocks submit, so a user can fill the form while the rest arrives. The wording now says which controls are disabled and why the others are not.

Tag `v0.7.3` after merge to publish.