### PR TITLE
fix(web-components): patch the streaming tail instead of replacing it

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mdocui/cli",
-	"version": "0.8.0",
+	"version": "0.8.1",
 	"description": "CLI for mdocUI — scaffold, generate system prompts, preview",
 	"type": "module",
 	"bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mdocui/core",
-	"version": "0.8.0",
+	"version": "0.8.1",
 	"description": "Streaming Markdoc parser, component registry, and system prompt generator for LLM generative UI",
 	"type": "module",
 	"main": "./dist/index.cjs",

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -107,11 +107,15 @@ export class StreamingParser {
 
 		let pendingTag: string | undefined
 		if (isBuffering && buffer.length > 2) {
-			const inner = buffer.slice(2).trim()
-			const spaceIdx = inner.indexOf(' ')
-			const rawName = spaceIdx === -1 ? inner : inner.slice(0, spaceIdx)
+			const afterDelimiter = buffer.slice(2).trimStart()
+			const spaceIdx = afterDelimiter.search(/\s/)
+			const rawName = spaceIdx === -1 ? afterDelimiter : afterDelimiter.slice(0, spaceIdx)
 			const name = rawName.endsWith('/') ? rawName.slice(0, -1) : rawName
-			if (name && !name.startsWith('/')) {
+			// Only report a name once something follows it. Until then "ca" could
+			// still become "card" or "callout", and a renderer would label a
+			// placeholder with a component that does not exist.
+			const settled = spaceIdx !== -1 || rawName.endsWith('/') || rawName.endsWith('%')
+			if (name && settled && !name.startsWith('/')) {
 				pendingTag = name
 			}
 		}
@@ -121,6 +125,7 @@ export class StreamingParser {
 			nodeCount: this.completedNodes.length,
 			isComplete: this.bodyStack.length === 0 && !isBuffering,
 			pendingTag: isBuffering ? pendingTag : undefined,
+			openTags: this.bodyStack.length > 0 ? this.bodyStack.map((f) => f.name) : undefined,
 			bufferLength: isBuffering ? buffer.length : undefined,
 		}
 	}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -58,7 +58,17 @@ export interface ParseMeta {
 	errors: ParseError[]
 	nodeCount: number
 	isComplete: boolean
+	/**
+	 * Name of the tag currently being read, once enough of it has arrived to
+	 * know what it is. Undefined while the name is still half typed.
+	 */
 	pendingTag?: string
+	/**
+	 * Components that have opened but not closed, outermost first. Their
+	 * contents are still being collected and will not appear as nodes until the
+	 * closing tag arrives, so a renderer showing progress needs this.
+	 */
+	openTags?: string[]
 	bufferLength?: number
 }
 

--- a/packages/core/tests/parser.test.ts
+++ b/packages/core/tests/parser.test.ts
@@ -367,3 +367,61 @@ describe('StreamingParser', () => {
 		})
 	})
 })
+
+describe('progress reporting while streaming', () => {
+	const known = new Set(['card', 'grid', 'stat', 'chart', 'callout'])
+
+	it('reports a tag name only once it is settled', () => {
+		const p = new StreamingParser({ knownTags: known })
+		p.write('{% ca')
+		// "ca" could still become card or callout, so nothing is claimed yet
+		expect(p.getMeta().pendingTag).toBeUndefined()
+		p.write('rd ')
+		expect(p.getMeta().pendingTag).toBe('card')
+	})
+
+	it('reports a self-closing name once the slash arrives', () => {
+		const p = new StreamingParser({ knownTags: known })
+		p.write('{% divider')
+		expect(p.getMeta().pendingTag).toBeUndefined()
+		p.write('/')
+		expect(p.getMeta().pendingTag).toBe('divider')
+	})
+
+	it('lists components whose body is still being collected', () => {
+		const p = new StreamingParser({ knownTags: known })
+		p.write('{% card title="C" %}')
+		expect(p.getMeta().openTags).toEqual(['card'])
+		p.write('{% grid cols=2 %}')
+		expect(p.getMeta().openTags).toEqual(['card', 'grid'])
+		p.write('{% /grid %}')
+		expect(p.getMeta().openTags).toEqual(['card'])
+		p.write('{% /card %}')
+		expect(p.getMeta().openTags).toBeUndefined()
+	})
+
+	it('has far less dead time with openTags than with pendingTag alone', () => {
+		const markup =
+			'{% card title="C" %}\n{% grid cols=2 %}\n{% stat label="A" value="1" /%}\n{% stat label="B" value="2" /%}\n{% /grid %}\n{% /card %}'
+		const count = (useOpenTags: boolean) => {
+			const p = new StreamingParser({ knownTags: known })
+			let blind = 0
+			let nodes = 0
+			for (let i = 0; i < markup.length; i += 4) {
+				p.write(markup.slice(i, i + 4))
+				const m = p.getMeta()
+				const label = useOpenTags
+					? (m.pendingTag ?? m.openTags?.[m.openTags.length - 1])
+					: m.pendingTag
+				const grew = p.getNodes().length > nodes
+				nodes = p.getNodes().length
+				if (!grew && !label && !m.isComplete) blind++
+			}
+			return blind
+		}
+		// the card only becomes a node at the very end, so on pendingTag alone this
+		// response renders nothing for long stretches
+		expect(count(true)).toBeLessThan(count(false))
+		expect(count(true)).toBeLessThanOrEqual(2)
+	})
+})

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mdocui/react",
-	"version": "0.8.0",
+	"version": "0.8.1",
 	"description": "React adapter for mdocUI — Renderer, useRenderer hook, default generative UI components",
 	"type": "module",
 	"main": "./dist/index.cjs",

--- a/packages/react/src/renderer.tsx
+++ b/packages/react/src/renderer.tsx
@@ -48,6 +48,13 @@ export function Renderer({
 
 	const grouped = groupButtons(nodes)
 
+	// A component with a body does not become a node until its closing tag
+	// lands, so a card wrapping a whole response shows nothing the entire time
+	// it streams. pendingTag only covers the moment a tag name is arriving, and
+	// goes undefined in between. Falling back to the innermost open tag keeps a
+	// placeholder up for as long as something is genuinely still being built.
+	const pendingLabel = meta?.pendingTag ?? meta?.openTags?.[meta.openTags.length - 1]
+
 	return (
 		<MdocUIProvider value={ctx}>
 			<div data-mdocui style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
@@ -70,12 +77,12 @@ export function Renderer({
 						item.node.type === 'component' ? `${item.node.name}-${idx}` : `prose-${idx}`
 					return renderNode(item.node, nodeKey, ctx, renderProse, classNames)
 				})}
-				{isStreaming && meta?.pendingTag && renderPendingComponent !== null && (
+				{isStreaming && pendingLabel && renderPendingComponent !== null && (
 					<div key="mdocui-shimmer">
 						{renderPendingComponent ? (
-							renderPendingComponent(meta.pendingTag)
+							renderPendingComponent(pendingLabel)
 						) : (
-							<ComponentShimmer pendingTag={meta.pendingTag} />
+							<ComponentShimmer pendingTag={pendingLabel} />
 						)}
 					</div>
 				)}

--- a/packages/react/tests/shimmer.test.tsx
+++ b/packages/react/tests/shimmer.test.tsx
@@ -96,3 +96,52 @@ describe('Renderer shimmer integration', () => {
 		expect(container.querySelector('[data-mdocui-shimmer]')).toBeNull()
 	})
 })
+
+describe('placeholder while a body streams', () => {
+	const meta = (over: Partial<ParseMeta>): ParseMeta => ({
+		errors: [],
+		nodeCount: 0,
+		isComplete: false,
+		...over,
+	})
+
+	it('shows a placeholder while a component body is still open', () => {
+		// pendingTag is undefined here: the opening tag is parsed and the body is
+		// streaming, which is most of the life of a card wrapping a response
+		const { container } = render(
+			<Renderer nodes={[]} isStreaming={true} meta={meta({ openTags: ['card'] })} />,
+		)
+		const el = container.querySelector('[data-mdocui-shimmer]') as HTMLElement
+		expect(el).toBeTruthy()
+		expect(el.getAttribute('data-pending-tag')).toBe('card')
+	})
+
+	it('names the innermost open component', () => {
+		const { container } = render(
+			<Renderer nodes={[]} isStreaming={true} meta={meta({ openTags: ['card', 'grid'] })} />,
+		)
+		expect(container.querySelector('[data-mdocui-shimmer]')?.getAttribute('data-pending-tag')).toBe(
+			'grid',
+		)
+	})
+
+	it('prefers the tag currently arriving over the open one', () => {
+		const { container } = render(
+			<Renderer
+				nodes={[]}
+				isStreaming={true}
+				meta={meta({ pendingTag: 'chart', openTags: ['card'] })}
+			/>,
+		)
+		expect(container.querySelector('[data-mdocui-shimmer]')?.getAttribute('data-pending-tag')).toBe(
+			'chart',
+		)
+	})
+
+	it('shows nothing once everything is closed', () => {
+		const { container } = render(
+			<Renderer nodes={[]} isStreaming={true} meta={meta({ isComplete: true })} />,
+		)
+		expect(container.querySelector('[data-mdocui-shimmer]')).toBeNull()
+	})
+})

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mdocui/web-components",
-	"version": "0.8.0",
+	"version": "0.8.1",
 	"description": "Custom element renderer for mdocUI — works in any framework, or none",
 	"type": "module",
 	"main": "./dist/index.cjs",

--- a/packages/web-components/src/dom.ts
+++ b/packages/web-components/src/dom.ts
@@ -60,3 +60,54 @@ export function append(parent: Node, child: Node | Node[] | null): void {
 export function clear(el: Node): void {
 	while (el.firstChild) el.removeChild(el.firstChild)
 }
+
+/**
+ * Update oldNode in place to match newNode. Swapping the tail on every chunk
+ * rebuilds whatever the reader is looking at, which flickers and kills text
+ * selection. Returns whichever node is now in the tree.
+ */
+export function patch(oldNode: Node, newNode: Node): Node {
+	if (oldNode.nodeType !== newNode.nodeType) {
+		oldNode.parentNode?.replaceChild(newNode, oldNode)
+		return newNode
+	}
+
+	if (oldNode.nodeType === 3) {
+		if (oldNode.nodeValue !== newNode.nodeValue) oldNode.nodeValue = newNode.nodeValue
+		return oldNode
+	}
+
+	if (oldNode.nodeType !== 1) return oldNode
+
+	const oldEl = oldNode as Element
+	const newEl = newNode as Element
+	if (oldEl.tagName !== newEl.tagName) {
+		oldEl.parentNode?.replaceChild(newEl, oldEl)
+		return newEl
+	}
+
+	for (const attr of Array.from(newEl.attributes)) {
+		if (oldEl.getAttribute(attr.name) !== attr.value) oldEl.setAttribute(attr.name, attr.value)
+	}
+	for (const attr of Array.from(oldEl.attributes)) {
+		if (!newEl.hasAttribute(attr.name)) oldEl.removeAttribute(attr.name)
+	}
+
+	const oldKids = Array.from(oldEl.childNodes)
+	const newKids = Array.from(newEl.childNodes)
+	for (let i = 0; i < Math.max(oldKids.length, newKids.length); i++) {
+		const o = oldKids[i]
+		const n = newKids[i]
+		if (n === undefined) {
+			if (o) oldEl.removeChild(o)
+			continue
+		}
+		if (o === undefined) {
+			oldEl.appendChild(n)
+			continue
+		}
+		patch(o, n)
+	}
+
+	return oldEl
+}

--- a/packages/web-components/src/element.ts
+++ b/packages/web-components/src/element.ts
@@ -8,7 +8,7 @@ import {
 	type ProseNode,
 	StreamingParser,
 } from '@mdocui/core'
-import { clear } from './dom'
+import { clear, patch } from './dom'
 import { releaseStreamDisabled } from './interactive'
 import { type CustomRenderer, renderItem } from './render'
 
@@ -165,10 +165,11 @@ export class MdocUIElement extends HTMLElement {
 		const old = this.rendered[index]
 		if (!replacement) return
 		if (old?.parentNode === this) {
-			this.replaceChild(replacement, old)
-		} else {
-			this.appendChild(replacement)
+			// Patch, don't swap. Swapping flickers.
+			this.rendered[index] = patch(old, replacement)
+			return
 		}
+		this.appendChild(replacement)
 		this.rendered[index] = replacement
 	}
 }

--- a/packages/web-components/src/element.ts
+++ b/packages/web-components/src/element.ts
@@ -11,6 +11,7 @@ import {
 import { clear, patch } from './dom'
 import { releaseStreamDisabled } from './interactive'
 import { type CustomRenderer, renderItem } from './render'
+import { createShimmer } from './shimmer'
 
 export const ACTION_EVENT = 'mdocui:action'
 export const ERROR_EVENT = 'mdocui:error'
@@ -37,6 +38,7 @@ export class MdocUIElement extends HTMLElement {
 	private renderedCount = 0
 	// Lets us skip rebuilding the tail when it hasn't actually changed.
 	private lastSignature = ''
+	private shimmer: HTMLElement | null = null
 	private streaming = false
 
 	classNames: Record<string, string> = {}
@@ -104,6 +106,7 @@ export class MdocUIElement extends HTMLElement {
 		this.lastSignature = ''
 		this.rendered = []
 		this.streaming = false
+		this.shimmer = null
 		clear(this)
 	}
 
@@ -157,8 +160,39 @@ export class MdocUIElement extends HTMLElement {
 		this.renderedCount = next.length
 		this.lastSignature = next.length > 0 ? signatureOf(next[next.length - 1]) : ''
 
+		this.syncShimmer()
+
 		// Re-enable rather than rebuild, or we'd wipe a half-filled form.
 		if (final) releaseStreamDisabled(this)
+	}
+
+	/**
+	 * Show a placeholder for a component that has started arriving but has not
+	 * closed yet. Prose can stream as text, a half-parsed tag cannot.
+	 */
+	private syncShimmer(): void {
+		const meta = this.streaming ? this.parser?.getMeta() : undefined
+		// openTags covers the long stretch where a component's body is streaming
+		// but its closing tag has not arrived, which pendingTag alone misses.
+		const pending = meta?.pendingTag ?? meta?.openTags?.[meta.openTags.length - 1]
+
+		if (!pending) {
+			this.shimmer?.remove()
+			this.shimmer = null
+			return
+		}
+
+		if (!this.shimmer) {
+			this.shimmer = createShimmer(pending)
+			this.appendChild(this.shimmer)
+			return
+		}
+
+		if (this.shimmer.getAttribute('data-pending-tag') !== pending) {
+			this.shimmer.setAttribute('data-pending-tag', pending)
+		}
+		// keep it last, since new nodes land after it
+		if (this.lastChild !== this.shimmer) this.appendChild(this.shimmer)
 	}
 
 	private replaceAt(index: number, replacement: Node | null): void {

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -7,6 +7,7 @@ export type { InteractiveArgs } from './interactive'
 export { renderProse } from './prose'
 export type { CustomRenderer, RenderOptions } from './render'
 export { renderNode, renderNodes } from './render'
+export { createShimmer } from './shimmer'
 
 import { defineMdocUI } from './element'
 

--- a/packages/web-components/src/shimmer.ts
+++ b/packages/web-components/src/shimmer.ts
@@ -1,0 +1,43 @@
+const KEYFRAMES_ID = 'mdocui-shimmer-keyframes'
+
+function ensureKeyframes(): void {
+	if (typeof document === 'undefined') return
+	if (document.getElementById(KEYFRAMES_ID)) return
+	const style = document.createElement('style')
+	style.id = KEYFRAMES_ID
+	style.textContent =
+		'@keyframes mdocui-shimmer { 0% { opacity: 0.15; } 50% { opacity: 0.35; } 100% { opacity: 0.15; } }'
+	document.head.appendChild(style)
+}
+
+/**
+ * Placeholder for a component whose tag has started arriving but has not
+ * finished. Text can stream a character at a time, a half-parsed component
+ * cannot, so it gets a shimmer until it is complete.
+ */
+export function createShimmer(pendingTag?: string): HTMLElement {
+	ensureKeyframes()
+
+	const box = document.createElement('div')
+	box.setAttribute('data-mdocui-shimmer', 'true')
+	if (pendingTag) box.setAttribute('data-pending-tag', pendingTag)
+	box.style.display = 'flex'
+	box.style.flexDirection = 'column'
+	box.style.gap = '10px'
+	box.style.padding = '16px'
+	box.style.borderRadius = '8px'
+	box.style.border = '1px solid currentColor'
+	box.style.opacity = '0.2'
+
+	for (const width of ['40%', '80%', '60%']) {
+		const bar = document.createElement('div')
+		bar.style.height = '12px'
+		bar.style.width = width
+		bar.style.borderRadius = '6px'
+		bar.style.background = 'currentColor'
+		bar.style.animation = 'mdocui-shimmer 1.5s ease-in-out infinite'
+		box.appendChild(bar)
+	}
+
+	return box
+}

--- a/packages/web-components/tests/element.test.ts
+++ b/packages/web-components/tests/element.test.ts
@@ -419,3 +419,45 @@ describe('streaming without flicker', () => {
 		expect(el.querySelector('ul')).not.toBeNull()
 	})
 })
+
+describe('pending component placeholder', () => {
+	it('shows a placeholder while a tag name is arriving', () => {
+		const el = create()
+		el.push('{% chart ')
+		expect(el.querySelector('[data-mdocui-shimmer]')).not.toBeNull()
+		expect(el.querySelector('[data-mdocui-shimmer]')?.getAttribute('data-pending-tag')).toBe(
+			'chart',
+		)
+	})
+
+	it('keeps the placeholder up while a body is still streaming', () => {
+		const el = create()
+		el.push('{% card title="C" %}')
+		// the card is not a node yet, so without this the pane would sit empty
+		expect(el.querySelector('[data-mdocui-shimmer]')).not.toBeNull()
+		el.push('some body text that goes on')
+		expect(el.querySelector('[data-mdocui-shimmer]')).not.toBeNull()
+		expect(el.querySelector('[data-mdocui-shimmer]')?.getAttribute('data-pending-tag')).toBe('card')
+	})
+
+	it('names the innermost thing being built', () => {
+		const el = create()
+		el.push('{% card title="C" %}{% grid cols=2 %}')
+		expect(el.querySelector('[data-mdocui-shimmer]')?.getAttribute('data-pending-tag')).toBe('grid')
+	})
+
+	it('removes the placeholder once everything closes', () => {
+		const el = create()
+		el.push('{% card title="C" %}body')
+		expect(el.querySelector('[data-mdocui-shimmer]')).not.toBeNull()
+		el.push('{% /card %}')
+		el.done()
+		expect(el.querySelector('[data-mdocui-shimmer]')).toBeNull()
+	})
+
+	it('keeps the placeholder last so finished content stays above it', () => {
+		const el = create()
+		el.push('intro text\n\n{% card title="C" %}')
+		expect(el.lastElementChild?.getAttribute('data-mdocui-shimmer')).toBe('true')
+	})
+})

--- a/packages/web-components/tests/element.test.ts
+++ b/packages/web-components/tests/element.test.ts
@@ -367,3 +367,55 @@ describe('host layout', () => {
 		expect(el.style.display).toBe('grid')
 	})
 })
+
+describe('streaming without flicker', () => {
+	it('keeps the same element while the tail grows', () => {
+		const el = create()
+		el.push('Some prose that ')
+		const first = el.firstElementChild
+		const firstP = el.querySelector('p')
+		el.push('keeps on ')
+		el.push('growing as it streams.')
+		el.done()
+		// same nodes, updated in place, not rebuilt
+		expect(el.firstElementChild).toBe(first)
+		expect(el.querySelector('p')).toBe(firstP)
+		expect(el.textContent).toContain('keeps on growing as it streams.')
+	})
+
+	it('does not remove nodes while the tail grows', () => {
+		const el = create()
+		el.push('one ')
+		let removed = 0
+		const obs = new MutationObserver((records) => {
+			for (const r of records) removed += r.removedNodes.length
+		})
+		obs.observe(el, { childList: true, subtree: true, characterData: true })
+		el.push('two ')
+		el.push('three')
+		el.done()
+		obs.disconnect()
+		expect(removed).toBe(0)
+	})
+
+	it('preserves a text selection inside the growing tail', () => {
+		const el = create()
+		el.push('hello world ')
+		const p = el.querySelector('p') as HTMLElement
+		const textNode = p.firstChild as Text
+		el.push('and more text')
+		el.done()
+		// the very same text node survived, so a selection anchored in it would too
+		expect(el.querySelector('p')?.firstChild).toBe(textNode)
+	})
+
+	it('still replaces when the tag actually changes', () => {
+		const el = create()
+		el.push('plain text')
+		const before = el.firstElementChild?.tagName
+		el.push('\n\n- now a list')
+		el.done()
+		expect(before).toBe('DIV')
+		expect(el.querySelector('ul')).not.toBeNull()
+	})
+})


### PR DESCRIPTION
The tail was rebuilt on every chunk, so the element the reader is looking at got destroyed and recreated dozens of times per response. That flickers, and it drops any text selection inside it.

Measured against the react renderer on the same markup, streaming at 4 characters per chunk:

| renderer | nodes added | nodes removed | top-level replacements |
|---|---|---|---|
| @mdocui/react | 13 | 4 | 0 |
| @mdocui/web-components (before) | 49 | 43 | **43** |
| @mdocui/web-components (after) | 9 | **0** | **0** |

Nodes are updated in place now, reusing the element and its text nodes where the tag has not changed, and only replacing when it genuinely changes, such as prose becoming a list.

Four tests cover it, including that a text node inside the growing tail survives. That is what makes a selection hold while the rest of the response arrives.

Found by streaming the same markup into both renderers and counting DOM churn with a MutationObserver.